### PR TITLE
Fix Dockerfile npm usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 # ✅ Raspberry Pi는 ARM이므로 node:18-alpine 사용 (경량)
-FROM node:18-slim 
+FROM node:18-slim
 
 # 앱 디렉토리 생성
 WORKDIR /app
 
 # 의존성 설치용 캐시
-COPY package.json pnpm-lock.yaml* ./
-RUN npm install -g pnpm && pnpm install
+COPY package.json package-lock.json ./
+RUN npm ci
 
 # 소스 복사
 COPY . .
 
 # 빌드
-RUN pnpm build
+RUN npm run build
 
 # 3000 포트 노출
 EXPOSE 3000
 
 # 실행
-CMD ["pnpm", "start"]
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- fix Dockerfile package manager usage to match repository setup

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843df3e3194832cb0ff84da9287a657