### PR TITLE
fix: mdx-layout import

### DIFF
--- a/src/content/posts/infinite-scroll.mdx
+++ b/src/content/posts/infinite-scroll.mdx
@@ -5,7 +5,7 @@ date: "2025-06-01"
 tags: ["무한 스크롤", "IntersectionObserver", "리액트 최적화", "Next.js", "면접 복기"]
 ---
 import InfiniteScrollBlogPage from '@/components/InfiniteScrollBlogPage'
-import {MdxLayout} from '@/components/mdx-layout'
+import MdxLayout from '@/components/mdx-layout'
 
 
 # 🌀 무한 스크롤 구현기와 최적화 고민


### PR DESCRIPTION
## Summary
- use default import for `mdx-layout`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f86439e8832c8ad8c7998fdc3ab0