### PR TITLE
Update slug extraction in blog page

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -9,8 +9,8 @@ interface Params {
 }
 
 export default async function BlogPostPage(props: Params) {
-  const params = await props.params;
-  const filePath = path.join(process.cwd(), "src/content/posts", `${params.slug}.mdx`);
+  const { slug } = props.params;
+  const filePath = path.join(process.cwd(), "src/content/posts", `${slug}.mdx`);
   const source = fs.readFileSync(filePath, "utf-8");
 
   const { content, frontmatter } = await compileMDX<{ title: string; date: string }>({


### PR DESCRIPTION
## Summary
- inline slug extraction in blog post page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843f86d7840832c9370aaa3b6dfad32