### PR TITLE
Fix Tailwind content path

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx}",
     "./src/**/*.{js,ts,jsx,tsx}",
-    "./content/**/*.{mdx}",
+    "./src/content/**/*.{mdx}",
   ],
   darkMode: "class",
   theme: {


### PR DESCRIPTION
## Summary
- update Tailwind `content` path to scan blog posts

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc79a694832c9d0a1c879ee1c331