### PR TITLE
Add type-check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Type Checking
+
+Run the following command to verify TypeScript types:
+
+```bash
+npm run type-check
+```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.0",


### PR DESCRIPTION
## Summary
- add npm script for TypeScript type checking
- mention `npm run type-check` in the docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find type definitions)*
- `npm run build` *(fails: next not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6843fc7f422c832c8ce638c28cbd26a8