### PR TITLE
Add dynamic blog metadata

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,10 +2,43 @@ import fs from "fs";
 import path from "path";
 import { compileMDX } from "next-mdx-remote/rsc";
 import { allMdxComponents } from "@/components/mdx-components";
-import remarkGfm from 'remark-gfm'
+import remarkGfm from "remark-gfm";
+import type { Metadata } from "next";
 
 interface Params {
   params: { slug: string };
+}
+
+export async function generateMetadata(
+  props: Params,
+): Promise<Metadata> {
+  const { slug } = props.params;
+  const filePath = path.join(
+    process.cwd(),
+    "src/content/posts",
+    `${slug}.mdx`,
+  );
+  const source = fs.readFileSync(filePath, "utf-8");
+
+  const { frontmatter } = await compileMDX<{
+    title: string;
+    description?: string;
+    summary?: string;
+    date: string;
+  }>({
+    source,
+    options: {
+      parseFrontmatter: true,
+      mdxOptions: {
+        remarkPlugins: [remarkGfm],
+      },
+    },
+  });
+
+  return {
+    title: frontmatter.title,
+    description: frontmatter.description ?? frontmatter.summary,
+  };
 }
 
 export default async function BlogPostPage(props: Params) {


### PR DESCRIPTION
## Summary
- support `generateMetadata` on blog post pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc8207dc832cb4cb4d79a3276af5